### PR TITLE
fix height difference calculation

### DIFF
--- a/lib/measures/add_wind_and_stack_open_area/README.md
+++ b/lib/measures/add_wind_and_stack_open_area/README.md
@@ -28,3 +28,6 @@ https://github.com/BuildingPerformanceSimulation/openstudio-measures/tree/master
 
 # Measure Updates January 19th, 2023 by Matthew Dahlhausen
 - Splits the measure into two versions.  add_wind_and_stack_open_area is now an OpenStudio measure, and the EnergyPlus version changed to add_wind_and_stack_open_area_legacy
+
+# Measure Updates March 7th, 2023 by Matthew Dahlhausen
+- Corrected height difference calculation from 1/2 window height to 1/4 window height (half the neutral pressure level).

--- a/lib/measures/add_wind_and_stack_open_area/measure.rb
+++ b/lib/measures/add_wind_and_stack_open_area/measure.rb
@@ -7,12 +7,12 @@ class AddWindAndStackOpenArea < OpenStudio::Measure::ModelMeasure
 
   # human readable description
   def description
-    return "This measure models natural ventilation to thermal zones with operable windows.  It is not intended to model natural ventilation that relies on interzone, stack driven air transfer."
+    return "This measure models natural ventilation to thermal zones with operable casement type windows.  It is not intended to model natural ventilation that relies on interzone, stack driven air transfer."
   end
 
   # human readable description of modeling approach
   def modeler_description
-    return "This measure adds ZoneVentilation:WindandStackOpenArea objects to a zone for each window of a specified operable window construction.  The user can specify values for minimum and maximum zone and outdoor air temperatures and wind speed that set limits on when the ventilation is active. The airflow rate is the quadrature sum of wind driven and stack effect driven air flow.  Airflow driven by wind is a function of opening effectiveness, area, scheduled open area fraction, and wind speed.  Airflow driven by the stack effect is a function of the discharge coefficient, area, scheduled open area fraction, and height difference to the neutral pressure level.  This measure takes the height difference as half the window height, and as such is only intended to model natural ventilation in single zones where a few large operable windows or doors account for the majority of operable area.  It is not intended to model natural ventilation that relies on interzone, stack driven air transfer where ventilation flow through a opening is unidirectional."
+    return "This measure adds ZoneVentilation:WindandStackOpenArea objects to a zone for each window of a specified operable window construction. The user can specify values for minimum and maximum zone and outdoor air temperatures and wind speed that set limits on when the ventilation is active. The airflow rate is the quadrature sum of wind driven and stack effect driven air flow. Airflow driven by wind is a function of opening effectiveness, area, scheduled open area fraction, and wind speed. Airflow driven by the stack effect is a function of the discharge coefficient, area, scheduled open area fraction, and height difference to the neutral pressure level. This measure takes the height difference as one quarter the window height, and as such is only intended to model natural ventilation in single zones where a few large operable casement type windows or doors account for the majority of operable area. It is not intended to model natural ventilation that relies on interzone, stack driven air transfer where ventilation flow through a opening is unidirectional."
   end
 
   # define the arguments that the user will input
@@ -380,10 +380,10 @@ class AddWindAndStackOpenArea < OpenStudio::Measure::ModelMeasure
       end
       sub_surface_zone = sub_surface_space.thermalZone.get
      
-      # calculate the height_difference at one half the window height
+      # calculate the height_difference at one quarter the window height. Assuming a casement type window or any type of door with the neutral pressure level (NPL) assumed to be 1/2 the window height and the midpoint of the lower opening (MP) being one half of the height between the bottom of the window and the NPL.
       z_values = []
       sub_surface.vertices.each { |v| z_values << v.z }
-      height_difference = (z_values.max - z_values.min) / 2.0
+      height_difference = (z_values.max - z_values.min) / 4.0
 
       # determine outward normal angle
       absolute_azimuth = OpenStudio.convert(sub_surface.azimuth, 'rad', 'deg').get + sub_surface.surface.get.space.get.directionofRelativeNorth + model.getBuilding.northAxis

--- a/lib/measures/add_wind_and_stack_open_area/measure.xml
+++ b/lib/measures/add_wind_and_stack_open_area/measure.xml
@@ -3,13 +3,13 @@
   <schema_version>3.0</schema_version>
   <name>add_wind_and_stack_open_area</name>
   <uid>c1290ecc-ef5b-4c64-8df5-367cc1129841</uid>
-  <version_id>3e05bc69-1a03-44f3-b594-39d2e614b0bd</version_id>
-  <version_modified>20230307T155649Z</version_modified>
+  <version_id>9753d948-7c88-4a0f-9055-e61f5145ada2</version_id>
+  <version_modified>20230307T161651Z</version_modified>
   <xml_checksum>E95EC1B5</xml_checksum>
   <class_name>AddWindAndStackOpenArea</class_name>
   <display_name>Add Wind and Stack Open Area</display_name>
-  <description>This measure models natural ventilation to thermal zones with operable windows.  It is not intended to model natural ventilation that relies on interzone, stack driven air transfer.</description>
-  <modeler_description>This measure adds ZoneVentilation:WindandStackOpenArea objects to a zone for each window of a specified operable window construction.  The user can specify values for minimum and maximum zone and outdoor air temperatures and wind speed that set limits on when the ventilation is active. The airflow rate is the quadrature sum of wind driven and stack effect driven air flow.  Airflow driven by wind is a function of opening effectiveness, area, scheduled open area fraction, and wind speed.  Airflow driven by the stack effect is a function of the discharge coefficient, area, scheduled open area fraction, and height difference to the neutral pressure level.  This measure takes the height difference as half the window height, and as such is only intended to model natural ventilation in single zones where a few large operable windows or doors account for the majority of operable area.  It is not intended to model natural ventilation that relies on interzone, stack driven air transfer where ventilation flow through a opening is unidirectional.</modeler_description>
+  <description>This measure models natural ventilation to thermal zones with operable casement type windows.  It is not intended to model natural ventilation that relies on interzone, stack driven air transfer.</description>
+  <modeler_description>This measure adds ZoneVentilation:WindandStackOpenArea objects to a zone for each window of a specified operable window construction. The user can specify values for minimum and maximum zone and outdoor air temperatures and wind speed that set limits on when the ventilation is active. The airflow rate is the quadrature sum of wind driven and stack effect driven air flow. Airflow driven by wind is a function of opening effectiveness, area, scheduled open area fraction, and wind speed. Airflow driven by the stack effect is a function of the discharge coefficient, area, scheduled open area fraction, and height difference to the neutral pressure level. This measure takes the height difference as one quarter the window height, and as such is only intended to model natural ventilation in single zones where a few large operable casement type windows or doors account for the majority of operable area. It is not intended to model natural ventilation that relies on interzone, stack driven air transfer where ventilation flow through a opening is unidirectional.</modeler_description>
   <arguments>
     <argument>
       <name>construction</name>
@@ -17,10 +17,10 @@
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
-      <default_value>{ca5699a6-e5e0-43ac-9a98-e280be422529}</default_value>
+      <default_value>{98d19d88-d434-453e-aed1-d19046d19019}</default_value>
       <choices>
         <choice>
-          <value>{ca5699a6-e5e0-43ac-9a98-e280be422529}</value>
+          <value>{98d19d88-d434-453e-aed1-d19046d19019}</value>
           <display_name>*All Operable Windows*</display_name>
         </choice>
       </choices>
@@ -32,10 +32,10 @@
       <type>Choice</type>
       <required>false</required>
       <model_dependent>false</model_dependent>
-      <default_value>{ca5699a6-e5e0-43ac-9a98-e280be422529}</default_value>
+      <default_value>{98d19d88-d434-453e-aed1-d19046d19019}</default_value>
       <choices>
         <choice>
-          <value>{ca5699a6-e5e0-43ac-9a98-e280be422529}</value>
+          <value>{98d19d88-d434-453e-aed1-d19046d19019}</value>
           <display_name>Default 0.5 Open Fractional Schedule</display_name>
         </choice>
       </choices>
@@ -56,10 +56,10 @@
       <type>Choice</type>
       <required>true</required>
       <model_dependent>false</model_dependent>
-      <default_value>{ca5699a6-e5e0-43ac-9a98-e280be422529}</default_value>
+      <default_value>{98d19d88-d434-453e-aed1-d19046d19019}</default_value>
       <choices>
         <choice>
-          <value>{ca5699a6-e5e0-43ac-9a98-e280be422529}</value>
+          <value>{98d19d88-d434-453e-aed1-d19046d19019}</value>
           <display_name>NA</display_name>
         </choice>
       </choices>
@@ -80,10 +80,10 @@
       <type>Choice</type>
       <required>true</required>
       <model_dependent>false</model_dependent>
-      <default_value>{ca5699a6-e5e0-43ac-9a98-e280be422529}</default_value>
+      <default_value>{98d19d88-d434-453e-aed1-d19046d19019}</default_value>
       <choices>
         <choice>
-          <value>{ca5699a6-e5e0-43ac-9a98-e280be422529}</value>
+          <value>{98d19d88-d434-453e-aed1-d19046d19019}</value>
           <display_name>NA</display_name>
         </choice>
       </choices>
@@ -104,10 +104,10 @@
       <type>Choice</type>
       <required>true</required>
       <model_dependent>false</model_dependent>
-      <default_value>{ca5699a6-e5e0-43ac-9a98-e280be422529}</default_value>
+      <default_value>{98d19d88-d434-453e-aed1-d19046d19019}</default_value>
       <choices>
         <choice>
-          <value>{ca5699a6-e5e0-43ac-9a98-e280be422529}</value>
+          <value>{98d19d88-d434-453e-aed1-d19046d19019}</value>
           <display_name>NA</display_name>
         </choice>
       </choices>
@@ -128,10 +128,10 @@
       <type>Choice</type>
       <required>true</required>
       <model_dependent>false</model_dependent>
-      <default_value>{ca5699a6-e5e0-43ac-9a98-e280be422529}</default_value>
+      <default_value>{98d19d88-d434-453e-aed1-d19046d19019}</default_value>
       <choices>
         <choice>
-          <value>{ca5699a6-e5e0-43ac-9a98-e280be422529}</value>
+          <value>{98d19d88-d434-453e-aed1-d19046d19019}</value>
           <display_name>NA</display_name>
         </choice>
       </choices>
@@ -152,10 +152,10 @@
       <type>Choice</type>
       <required>true</required>
       <model_dependent>false</model_dependent>
-      <default_value>{ca5699a6-e5e0-43ac-9a98-e280be422529}</default_value>
+      <default_value>{98d19d88-d434-453e-aed1-d19046d19019}</default_value>
       <choices>
         <choice>
-          <value>{ca5699a6-e5e0-43ac-9a98-e280be422529}</value>
+          <value>{98d19d88-d434-453e-aed1-d19046d19019}</value>
           <display_name>NA</display_name>
         </choice>
       </choices>
@@ -204,17 +204,6 @@
   </attributes>
   <files>
     <file>
-      <version>
-        <software_program>OpenStudio</software_program>
-        <identifier>3.0</identifier>
-        <min_compatible>3.0</min_compatible>
-      </version>
-      <filename>measure.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>script</usage_type>
-      <checksum>79AA44B0</checksum>
-    </file>
-    <file>
       <filename>LICENSE.md</filename>
       <filetype>md</filetype>
       <usage_type>license</usage_type>
@@ -233,10 +222,21 @@
       <checksum>20DC1946</checksum>
     </file>
     <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>3.0</identifier>
+        <min_compatible>3.0</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>3C9A27A8</checksum>
+    </file>
+    <file>
       <filename>README.md</filename>
       <filetype>md</filetype>
       <usage_type>readme</usage_type>
-      <checksum>5F81D4A3</checksum>
+      <checksum>4E4704D8</checksum>
     </file>
   </files>
 </measure>

--- a/lib/measures/add_wind_and_stack_open_area_legacy/README.md
+++ b/lib/measures/add_wind_and_stack_open_area_legacy/README.md
@@ -28,3 +28,6 @@ https://github.com/BuildingPerformanceSimulation/openstudio-measures/tree/master
 
 # Measure Updates January 19th, 2023 by Matthew Dahlhausen
 - Splits the measure into two versions.  add_wind_and_stack_open_area is now an OpenStudio measure, and the EnergyPlus version changed to add_wind_and_stack_open_area_legacy
+
+# Measure Updates March 7th, 2023 by Matthew Dahlhausen
+- Corrected height difference calculation from 1/2 window height to 1/4 window height (half the neutral pressure level).

--- a/lib/measures/add_wind_and_stack_open_area_legacy/measure.rb
+++ b/lib/measures/add_wind_and_stack_open_area_legacy/measure.rb
@@ -7,12 +7,12 @@ class AddWindAndStackOpenAreaLegacy < OpenStudio::Measure::EnergyPlusMeasure
 
   # human readable description
   def description
-    return "This measure models natural ventilation to thermal zones with operable windows.  It is not intended to model natural ventilation that relies on interzone, stack driven air transfer."
+    return "This measure models natural ventilation to thermal zones with operable casement type windows.  It is not intended to model natural ventilation that relies on interzone, stack driven air transfer."
   end
 
   # human readable description of modeling approach
   def modeler_description
-    return "This measure adds ZoneVentilation:WindandStackOpenArea objects to a zone for each window of a specified operable window construction.  The user can specify values for minimum and maximum zone and outdoor air temperatures and wind speed that set limits on when the ventilation is active. The airflow rate is the quadrature sum of wind driven and stack effect driven air flow.  Airflow driven by wind is a function of opening effectiveness, area, scheduled open area fraction, and wind speed.  Airflow driven by the stack effect is a function of the discharge coefficient, area, scheduled open area fraction, and height difference to the neutral pressure level.  This measure takes the height difference as half the window height, and as such is only intended to model natural ventilation in single zones where a few large operable windows or doors account for the majority of operable area.  It is not intended to model natural ventilation that relies on interzone, stack driven air transfer where ventilation flow through a opening is unidirectional."
+    return "This measure adds ZoneVentilation:WindandStackOpenArea objects to a zone for each window of a specified operable window construction. The user can specify values for minimum and maximum zone and outdoor air temperatures and wind speed that set limits on when the ventilation is active. The airflow rate is the quadrature sum of wind driven and stack effect driven air flow. Airflow driven by wind is a function of opening effectiveness, area, scheduled open area fraction, and wind speed. Airflow driven by the stack effect is a function of the discharge coefficient, area, scheduled open area fraction, and height difference to the neutral pressure level. This measure takes the height difference as one quarter the window height, and as such is only intended to model natural ventilation in single zones where a few large operable casement type windows or doors account for the majority of operable area. It is not intended to model natural ventilation that relies on interzone, stack driven air transfer where ventilation flow through a opening is unidirectional."
   end
 
   ###
@@ -142,7 +142,7 @@ class AddWindAndStackOpenAreaLegacy < OpenStudio::Measure::EnergyPlusMeasure
     end
 
     height = (zmax - zmin)
-    return height / 2.0
+    return height / 4.0
   end
 
   def get_window_effective_angle(workspace, window)
@@ -498,7 +498,7 @@ class AddWindAndStackOpenAreaLegacy < OpenStudio::Measure::EnergyPlusMeasure
       # calculate open_area size
       open_area = get_window_area(workspace, w)
 
-      # calculate the height_difference at one half the window height.  See notes for explanation.
+      # calculate the height_difference at one quarter the window height. Assuming a casement type window or any type of door with the neutral pressure level (NPL) assumed to be 1/2 the window height and the midpoint of the lower opening (MP) being one half of the height between the bottom of the window and the NPL.
       height_difference = get_window_height_difference(workspace, w)
 
       # determine outward normal angle for surface; need one for each window object

--- a/lib/measures/add_wind_and_stack_open_area_legacy/measure.xml
+++ b/lib/measures/add_wind_and_stack_open_area_legacy/measure.xml
@@ -3,13 +3,13 @@
   <schema_version>3.0</schema_version>
   <name>add_wind_and_stack_open_area_legacy</name>
   <uid>39cf10cd-cc6f-4b0e-9913-f77d8aa30f3c</uid>
-  <version_id>7feb854d-d921-4c43-af92-55ac4c9b5786</version_id>
-  <version_modified>20230307T155638Z</version_modified>
+  <version_id>dde5a6f8-2bf6-465f-a759-512190951c8f</version_id>
+  <version_modified>20230307T161645Z</version_modified>
   <xml_checksum>6716C5EC</xml_checksum>
   <class_name>AddWindAndStackOpenAreaLegacy</class_name>
   <display_name>Add Wind and Stack Open Area Legacy</display_name>
-  <description>This measure models natural ventilation to thermal zones with operable windows.  It is not intended to model natural ventilation that relies on interzone, stack driven air transfer.</description>
-  <modeler_description>This measure adds ZoneVentilation:WindandStackOpenArea objects to a zone for each window of a specified operable window construction.  The user can specify values for minimum and maximum zone and outdoor air temperatures and wind speed that set limits on when the ventilation is active. The airflow rate is the quadrature sum of wind driven and stack effect driven air flow.  Airflow driven by wind is a function of opening effectiveness, area, scheduled open area fraction, and wind speed.  Airflow driven by the stack effect is a function of the discharge coefficient, area, scheduled open area fraction, and height difference to the neutral pressure level.  This measure takes the height difference as half the window height, and as such is only intended to model natural ventilation in single zones where a few large operable windows or doors account for the majority of operable area.  It is not intended to model natural ventilation that relies on interzone, stack driven air transfer where ventilation flow through a opening is unidirectional.</modeler_description>
+  <description>This measure models natural ventilation to thermal zones with operable casement type windows.  It is not intended to model natural ventilation that relies on interzone, stack driven air transfer.</description>
+  <modeler_description>This measure adds ZoneVentilation:WindandStackOpenArea objects to a zone for each window of a specified operable window construction. The user can specify values for minimum and maximum zone and outdoor air temperatures and wind speed that set limits on when the ventilation is active. The airflow rate is the quadrature sum of wind driven and stack effect driven air flow. Airflow driven by wind is a function of opening effectiveness, area, scheduled open area fraction, and wind speed. Airflow driven by the stack effect is a function of the discharge coefficient, area, scheduled open area fraction, and height difference to the neutral pressure level. This measure takes the height difference as one quarter the window height, and as such is only intended to model natural ventilation in single zones where a few large operable casement type windows or doors account for the majority of operable area. It is not intended to model natural ventilation that relies on interzone, stack driven air transfer where ventilation flow through a opening is unidirectional.</modeler_description>
   <arguments>
     <argument>
       <name>construction</name>
@@ -221,13 +221,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>4B016109</checksum>
+      <checksum>4DACFD4F</checksum>
     </file>
     <file>
       <filename>README.md</filename>
       <filetype>md</filetype>
       <usage_type>readme</usage_type>
-      <checksum>5F81D4A3</checksum>
+      <checksum>4E4704D8</checksum>
     </file>
   </files>
 </measure>


### PR DESCRIPTION
Use 1/4 window height (half of neutral pressure level, assumed to be the midpoint of the window).